### PR TITLE
Links zu API Specs hinzugefügt

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,21 +16,22 @@ Mit der Report-API lassen sich Europace-Reports erzeugen und abrufen.
 
 ---
 
-# Dokumentation
+<h2>Inhalt</h2>
 
 <!-- TOC depthFrom:2 -->
 
+- [Getting Started](#getting-started)
 - [Europace-Reports](#europace-reports)
-- [Anwendungsfälle](#anwendungsfälle)
-- [API Referenz](#api-referenz)
-    - [Als OpenAPI 3 Spezifikation](#als-openapi-3-spezifikation)
-    - [Als HTML Seite](#als-html-seite)
-- [Schnellstart](#schnellstart)
-- [1. Report anfragen](#1-report-anfragen)
+    - [Anwendungsfälle](#anwendungsfälle)
+- [Dokumentation](#dokumentation)
+    - [OpenAPI 3 Spezifikation](#openapi-3-spezifikation)
     - [Authentifizierung](#authentifizierung)
-    - [Anfrage](#anfrage)
-- [2. Report Status abfragen](#2-report-status-abfragen)
-- [3. Report abholen](#3-report-abholen)
+    - [Beispielaufruf](#beispielaufruf)
+    - [Workflow und UML Sequenzdiagramme](#workflow-und-uml-sequenzdiagramme)
+- [Beispiel: Rohdaten-Report anfragen](#beispiel-rohdaten-report-anfragen)
+    - [1. Report anfragen](#1-report-anfragen)
+    - [2. Report Status abfragen](#2-report-status-abfragen)
+    - [3. Report abholen](#3-report-abholen)
 - [Nutzungsbedingungen](#nutzungsbedingungen)
 - [Support](#support)
 
@@ -39,6 +40,9 @@ Mit der Report-API lassen sich Europace-Reports erzeugen und abrufen.
 
 ---
 
+## Getting Started
+
+Erste Schritte zur Nutzung der Europace APIs sind [hier](https://docs.api.europace.de/baufinanzierung/schnellstart/) zu finden.
 
 ## Europace-Reports
 
@@ -47,25 +51,49 @@ Mit der Report-API lassen sich Europace-Reports erzeugen und abrufen.
 | Rohdaten-Report                                   | ```/rohdaten```        | `report:rohdaten:lesen`        | alle relevanten Daten von Vorgängen, Anträgen, Bausteinen und Provisionen des Vertriebs |
 | Produktanbieter-Report (:construction: in Arbeit) | ```/produktanbieter``` | `report:produktanbieter:lesen` | die wesentlichen Antragsdaten mit Status und Vertriebsorganisation                      |
 
-## Anwendungsfälle
+### Anwendungsfälle
 - Europace-Reports in Dataware-House ETL-Jobs einbinden
 - Europace-Reports in Vertriebstools anbieten
 
 
-## API Referenz
+## Dokumentation
 
-### Als OpenAPI 3 Spezifikation
+### OpenAPI 3 Spezifikation
 
 **JSON**
 
 - https://report.api.europace.de/documentation
 
-### Als HTML Seite
+**als HTML Seite**
 
 - https://europace.github.io/report-api/index.html
 
 
-## Schnellstart
+### Authentifizierung
+
+Bitte benutze [![Authentication](https://img.shields.io/badge/Auth-OAuth2-green)](https://github.com/europace/authorization-api), um Zugang zur Report-API zu bekommen.
+
+Welchen Scope du für welchen Report benötigst, siehst du unter [Europace-Reports](https://github.com/europace/report-api#europace-reports).
+
+Das Token muss auf die angefragte `partnerId` zugreifen dürfen (Hierarchie der Plakette)
+
+### Beispielaufruf
+
+```bash
+# Reportanfrage starten
+curl --location --request POST 'https://report.api.europace.de/rohdaten' \
+  --header 'Authorization: Bearer JW-Token' \
+  --data-raw '{
+      "partnerId": "ABC67",
+      "fromDay": "2020-01-01"
+    }'
+  
+# Status der Reportbearbeitung überprüfen und Ergebnis abrufen
+curl --location --request GET 'https://report.api.europace.de/rohdaten/<report-id>' \
+  --header 'Authorization: Bearer JW-Token' 
+```
+
+### Workflow und UML Sequenzdiagramme 
 
 Die Bearbeitung der Reportanfragen erfolgt asynchron, um Netzwerk-Timeouts bei der Erstellung der Reports zu vermeiden. Auf die Fertigstellung des Reports muss aktiv getestet werden.
 
@@ -79,17 +107,10 @@ Die Arbeitsweise ist bei allen Europace-Reports dieselbe:
 
 ![Tipp](https://img.shields.io/badge/-Tipp-yellow) Damit du unsere APIs und deinen Anwendungsfall schnellstmöglich testen kannst, haben wir eine [Postman-Collection](https://github.com/europace/api-schnellstart) für dich zusammengestellt, mit der du die folgenden Schritte einfach nachvollziehen kannst.
 
-## 1. Report anfragen
-Hier am Beispiel des Rohdaten-Report.
+## Beispiel: Rohdaten-Report anfragen
 
-### Authentifizierung
-Bitte benutze [![Authentication](https://img.shields.io/badge/Auth-OAuth2-green)](https://github.com/europace/authorization-api), um Zugang zur Report-API zu bekommen.
+### 1. Report anfragen
 
-Welchen Scope du für welchen Report benötigst, siehst du unter [Europace-Reports](https://github.com/europace/report-api#europace-reports).
-
-Das Token muss auf die angefragte `partnerId` zugreifen dürfen (Hierarchie der Plakette)
-
-### Anfrage
 Mit der Anfrage, wird bei Europace die Erzeugung des Report gestartet. Dieser Vorgang kann je nach Komplexität und abgefragtem Zeitraum mehrere Minuten in Anspruch nehmen. Die gültigen Parameter für die Erstellung des Report findest du in der entsprechenden Report-Beschreibung.
 
 Request für Rohdaten-Report:
@@ -117,7 +138,7 @@ Header:
 
 Die Header-Variable `Location` zeigt auf den Endpunkt für den nächsten Schritt: den Report Status abzufragen.
 
-## 2. Report Status abfragen
+### 2. Report Status abfragen
 
 Dieser Schritt ist für alle Europace-Reports gleich.
 
@@ -150,7 +171,7 @@ Header:
 ```
 Die Header-Variable `Location` zeigt auf die Reportdaten.
 
-## 3. Report abholen
+### 3. Report abholen
 
 Dieser Schritt ist für alle Europace-Reports gleich.
 

--- a/README.md
+++ b/README.md
@@ -19,13 +19,13 @@ abgerufen werden.
 
 [![YAML](https://img.shields.io/badge/OAS-HTML_Doc-lightblue)](https://europace.github.io/report-api/index.html)
 [![YAML](https://img.shields.io/badge/OAS-YAML-lightgrey)](https://github.com/europace/report-api/blob/master/report-api.yml)
-[![YAML](https://img.shields.io/badge/OAS-JSON-lightgrey)](https://europace.github.io/report-api/index.html)
+[![YAML](https://img.shields.io/badge/OAS-JSON-lightgrey)](https://report.api.europace.de/documentation)
 
-## Anwendungsfälle
+## Anwendungsfälle der API
 - Europace-Reports in Dataware-House ETL-Jobs einbinden
 - Europace-Reports in Vertriebstools anbieten
 
-## Europace-Reports
+## Übersicht Europace-Reports
 Folgende Reports können mit dieser API angerufen werden:
 
  Name | Endpunkt | benötigter Scope | Dateityp | Inhalts-Beschreibung
@@ -47,16 +47,16 @@ Die Arbeitsweise ist bei allen Europace-Reports dieselbe:
 
 ![Tipp](https://img.shields.io/badge/-Tipp-yellow) Damit du unsere APIs und deinen Anwendungsfall schnellstmöglich testen kannst, haben wir eine [Postman-Collection](https://github.com/europace/api-schnellstart) für dich zusammengestellt, mit der du die folgenden Schritte einfach nachvollziehen kannst.
 
-### Beispiel: Rohdaten-Report anfragen
+## Beispiel: Rohdaten-Report anfragen
 
-#### Authentifizierung
+### Authentifizierung
 Bitte benutze [![Authentication](https://img.shields.io/badge/Auth-OAuth2-green)](https://github.com/europace/authorization-api), um Zugang zur Report-API zu bekommen.
 
-Welchen Scope du für welchen Report benötigst, siehst du unter Europace-Reports.
+Welchen Scope du für welchen Report benötigst, siehst du in der [Übersicht Europace-Reports](https://docs.api.europace.de/baufinanzierung/report/report-api/#europace-reports).
 
 Das Token muss auf die angefragte `partnerId` zugreifen dürfen (Hierarchie der Plakette)
 
-#### 1. Report anfragen
+### 1. Report anfragen
 Mit der Anfrage, wird bei Europace die Erzeugung des Report gestartet. Dieser Vorgang kann je nach Komplexität und abgefragtem Zeitraum mehrere Minuten in Anspruch nehmen. Die gültigen Parameter für die Erstellung des Report findest du in der entsprechenden Report-Beschreibung.
 
 Request für Rohdaten-Report:
@@ -79,7 +79,7 @@ Header:
 
 Die Header-Variable `Location` zeigt auf den Endpunkt für den nächsten Schritt: den Report Status abzufragen.
 
-#### 2. Report Status abfragen
+### 2. Report Status abfragen
 
 Dieser Schritt ist für alle Europace-Reports gleich.
 
@@ -109,7 +109,7 @@ Header:
 ```
 Die Header-Variable `Location` zeigt auf die Reportdaten.
 
-#### 3. Report abholen
+### 3. Report abholen
 
 Dieser Schritt ist für alle Europace-Reports gleich.
 
@@ -132,7 +132,7 @@ Header:
 Body:
 <File>
 ```
-Den Dateityp von <file> kann den Europace-Reports entnommen werden.
+Der Dateityp von `<file>` ist in der [Übersicht Europace-Reports](https://docs.api.europace.de/baufinanzierung/report/report-api/#europace-reports) beschrieben.
 
 ## Nutzungsbedingungen
 Die APIs werden unter folgenden [Nutzungsbedingungen](https://docs.api.europace.de/nutzungsbedingungen/) zur Verfügung gestellt.

--- a/README.md
+++ b/README.md
@@ -14,16 +14,56 @@ Mit der Report-API lassen sich Europace-Reports erzeugen und abrufen.
 [![GitHub release](https://img.shields.io/github/v/release/europace/report-api)](https://github.com/europace/report-api/releases)
 [![Pattern](https://img.shields.io/badge/Pattern-Tolerant%20Reader-yellowgreen)](https://martinfowler.com/bliki/TolerantReader.html)
 
+---
+
+# Dokumentation
+
+<!-- TOC depthFrom:2 -->
+
+- [Europace-Reports](#europace-reports)
+- [Anwendungsfälle](#anwendungsfälle)
+- [API Referenz](#api-referenz)
+    - [Als OpenAPI 3 Spezifikation](#als-openapi-3-spezifikation)
+    - [Als HTML Seite](#als-html-seite)
+- [Schnellstart](#schnellstart)
+- [1. Report anfragen](#1-report-anfragen)
+    - [Authentifizierung](#authentifizierung)
+    - [Anfrage](#anfrage)
+- [2. Report Status abfragen](#2-report-status-abfragen)
+- [3. Report abholen](#3-report-abholen)
+- [Nutzungsbedingungen](#nutzungsbedingungen)
+- [Support](#support)
+
+<!-- /TOC -->
+
+
+---
+
+
 ## Europace-Reports
 
- Name | Endpunkt | benötigter Scope | Inhalts-Beschreibung
- ---- | ---- | ---- | ----
- Rohdaten-Report | ```/rohdaten``` | `report:rohdaten:lesen`  | alle relevanten Daten von Vorgängen, Anträgen, Bausteinen und Provisionen des Vertriebs |
-Produktanbieter-Report (:construction: in Arbeit)  | ```/produktanbieter``` | `report:produktanbieter:lesen`  | die wesentlichen Antragsdaten mit Status und Vertriebsorganisation |
+| Name                                              | Endpunkt               | benötigter Scope               | Inhalts-Beschreibung                                                                    |
+|---------------------------------------------------|------------------------|--------------------------------|-----------------------------------------------------------------------------------------|
+| Rohdaten-Report                                   | ```/rohdaten```        | `report:rohdaten:lesen`        | alle relevanten Daten von Vorgängen, Anträgen, Bausteinen und Provisionen des Vertriebs |
+| Produktanbieter-Report (:construction: in Arbeit) | ```/produktanbieter``` | `report:produktanbieter:lesen` | die wesentlichen Antragsdaten mit Status und Vertriebsorganisation                      |
 
 ## Anwendungsfälle
 - Europace-Reports in Dataware-House ETL-Jobs einbinden
 - Europace-Reports in Vertriebstools anbieten
+
+
+## API Referenz
+
+### Als OpenAPI 3 Spezifikation
+
+**JSON**
+
+- https://report.api.europace.de/documentation
+
+### Als HTML Seite
+
+- https://europace.github.io/report-api/index.html
+
 
 ## Schnellstart
 

--- a/README.md
+++ b/README.md
@@ -8,94 +8,34 @@ Mit der Report-API lassen sich Europace-Reports erzeugen und abrufen.
 ![Privatkredit](https://img.shields.io/badge/-Privatkredit-lightblue)
 
 [![Authentication](https://img.shields.io/badge/Auth-OAuth2-green)](https://github.com/europace/authorization-api)
-[![YAML](https://img.shields.io/badge/{}-YAML-green)](https://github.com/europace/report-api/blob/master/report-api.yml)
 [![Github](https://img.shields.io/badge/-Github-black?logo=github)](https://github.com/europace/report-api)
 
 [![GitHub release](https://img.shields.io/github/v/release/europace/report-api)](https://github.com/europace/report-api/releases)
 [![Pattern](https://img.shields.io/badge/Pattern-Tolerant%20Reader-yellowgreen)](https://martinfowler.com/bliki/TolerantReader.html)
 
----
+## Dokumentation
+Die aktuellste Open-Api-Specification im json-Format kann jederzeit unter `https://report.api.europace.de/documentation`
+abgerufen werden.
 
-<h2>Inhalt</h2>
+[![YAML](https://img.shields.io/badge/OAS-HTML_Doc-lightblue)](https://europace.github.io/report-api/index.html)
+[![YAML](https://img.shields.io/badge/OAS-YAML-lightgrey)](https://github.com/europace/report-api/blob/master/report-api.yml)
+[![YAML](https://img.shields.io/badge/OAS-JSON-lightgrey)](https://europace.github.io/report-api/index.html)
 
-<!-- TOC depthFrom:2 -->
-
-- [Getting Started](#getting-started)
-- [Europace-Reports](#europace-reports)
-    - [Anwendungsfälle](#anwendungsfälle)
-- [Dokumentation](#dokumentation)
-    - [OpenAPI 3 Spezifikation](#openapi-3-spezifikation)
-    - [Authentifizierung](#authentifizierung)
-    - [Beispielaufruf](#beispielaufruf)
-    - [Workflow und UML Sequenzdiagramme](#workflow-und-uml-sequenzdiagramme)
-- [Beispiel: Rohdaten-Report anfragen](#beispiel-rohdaten-report-anfragen)
-    - [1. Report anfragen](#1-report-anfragen)
-    - [2. Report Status abfragen](#2-report-status-abfragen)
-    - [3. Report abholen](#3-report-abholen)
-- [Nutzungsbedingungen](#nutzungsbedingungen)
-- [Support](#support)
-
-<!-- /TOC -->
-
-
----
-
-## Getting Started
-
-Erste Schritte zur Nutzung der Europace APIs sind [hier](https://docs.api.europace.de/baufinanzierung/schnellstart/) zu finden.
-
-## Europace-Reports
-
-| Name                                              | Endpunkt               | benötigter Scope               | Inhalts-Beschreibung                                                                    |
-|---------------------------------------------------|------------------------|--------------------------------|-----------------------------------------------------------------------------------------|
-| Rohdaten-Report                                   | ```/rohdaten```        | `report:rohdaten:lesen`        | alle relevanten Daten von Vorgängen, Anträgen, Bausteinen und Provisionen des Vertriebs |
-| Produktanbieter-Report (:construction: in Arbeit) | ```/produktanbieter``` | `report:produktanbieter:lesen` | die wesentlichen Antragsdaten mit Status und Vertriebsorganisation                      |
-
-### Anwendungsfälle
+## Anwendungsfälle
 - Europace-Reports in Dataware-House ETL-Jobs einbinden
 - Europace-Reports in Vertriebstools anbieten
 
+## Europace-Reports
+Folgende Reports können mit dieser API angerufen werden:
 
-## Dokumentation
+ Name | Endpunkt | benötigter Scope | Dateityp | Inhalts-Beschreibung
+ ---- | ---- | ---- | :----: | ---
+ Rohdaten-Report | ```/rohdaten``` | `report:rohdaten:lesen`  | zip | alle relevanten Daten von Vorgängen, Anträgen, Bausteinen und Provisionen des Vertriebs |
+Produktanbieter-Report (:construction: in Arbeit)  | ```/produktanbieter``` | `report:produktanbieter:lesen`  | csv | die wesentlichen Antragsdaten mit Status und Vertriebsorganisation |
 
-### OpenAPI 3 Spezifikation
+## Schnellstart
 
-**JSON**
-
-- https://report.api.europace.de/documentation
-
-**als HTML Seite**
-
-- https://europace.github.io/report-api/index.html
-
-
-### Authentifizierung
-
-Bitte benutze [![Authentication](https://img.shields.io/badge/Auth-OAuth2-green)](https://github.com/europace/authorization-api), um Zugang zur Report-API zu bekommen.
-
-Welchen Scope du für welchen Report benötigst, siehst du unter [Europace-Reports](https://github.com/europace/report-api#europace-reports).
-
-Das Token muss auf die angefragte `partnerId` zugreifen dürfen (Hierarchie der Plakette)
-
-### Beispielaufruf
-
-```bash
-# Reportanfrage starten
-curl --location --request POST 'https://report.api.europace.de/rohdaten' \
-  --header 'Authorization: Bearer JW-Token' \
-  --data-raw '{
-      "partnerId": "ABC67",
-      "fromDay": "2020-01-01"
-    }'
-  
-# Status der Reportbearbeitung überprüfen und Ergebnis abrufen
-curl --location --request GET 'https://report.api.europace.de/rohdaten/<report-id>' \
-  --header 'Authorization: Bearer JW-Token' 
-```
-
-### Workflow und UML Sequenzdiagramme 
-
-Die Bearbeitung der Reportanfragen erfolgt asynchron, um Netzwerk-Timeouts bei der Erstellung der Reports zu vermeiden. Auf die Fertigstellung des Reports muss aktiv getestet werden.
+Der Abruf der Ep2_Reports erfolgt asynchron, um Netzwerk-Timeouts bei der Erstellung der Reports zu vermeiden. Auf die Fertigstellung des Reports muss aktiv getestet werden.
 
 Die Arbeitsweise ist bei allen Europace-Reports dieselbe:
 
@@ -107,55 +47,53 @@ Die Arbeitsweise ist bei allen Europace-Reports dieselbe:
 
 ![Tipp](https://img.shields.io/badge/-Tipp-yellow) Damit du unsere APIs und deinen Anwendungsfall schnellstmöglich testen kannst, haben wir eine [Postman-Collection](https://github.com/europace/api-schnellstart) für dich zusammengestellt, mit der du die folgenden Schritte einfach nachvollziehen kannst.
 
-## Beispiel: Rohdaten-Report anfragen
+### Beispiel: Rohdaten-Report anfragen
 
-### 1. Report anfragen
+#### Authentifizierung
+Bitte benutze [![Authentication](https://img.shields.io/badge/Auth-OAuth2-green)](https://github.com/europace/authorization-api), um Zugang zur Report-API zu bekommen.
 
+Welchen Scope du für welchen Report benötigst, siehst du unter Europace-Reports.
+
+Das Token muss auf die angefragte `partnerId` zugreifen dürfen (Hierarchie der Plakette)
+
+#### 1. Report anfragen
 Mit der Anfrage, wird bei Europace die Erzeugung des Report gestartet. Dieser Vorgang kann je nach Komplexität und abgefragtem Zeitraum mehrere Minuten in Anspruch nehmen. Die gültigen Parameter für die Erstellung des Report findest du in der entsprechenden Report-Beschreibung.
 
 Request für Rohdaten-Report:
 ```
-POST https://report.api.europace.de/rohdaten
-
-Header:
-  * Authentication: "Bearer {token}"
-  * Content-Type: "application/json"
-  * Trace-Id: "{traceId}" (Optional)
-
-Body:
-{
-    "partnerId": "ABC12",
-    "fromDay": "2020-10-01"
-}
+curl --location --request POST 'https://report.api.europace.de/rohdaten' \
+--header 'X-Trace-Id: ' \
+--header 'Authorization: Bearer {access-token}' \
+--data-raw '{
+    "partnerId": "ABC06",
+    "fromDay": "2020-01-01"
+}'
 ```
 
 Response:
 ```
 Header:
-  * Status: 202 ACCEPTED
-  * Location: /rohdaten/{report-processing-id}
+  - Status: 202 ACCEPTED
+  - Location: /rohdaten/{report-processing-id}
 ```
 
 Die Header-Variable `Location` zeigt auf den Endpunkt für den nächsten Schritt: den Report Status abzufragen.
 
-### 2. Report Status abfragen
+#### 2. Report Status abfragen
 
 Dieser Schritt ist für alle Europace-Reports gleich.
 
 Request:
 ```
-GET https://report.api.europace.de/rohdaten/{report-processing-id}
-
-Header:
-  * Authentication: "Bearer {token}"
-  * Trace-Id: "{traceId}" (Optional)
+curl --location --request GET 'https://report.api.europace.de/rohdaten/{report-processing-id}' \
+--header 'X-Trace-Id: ' \
+--header 'Authorization: Bearer {access-token}'
 ```
 
 **(a)** Response für den Fall, dass Erstellung des Europace-Report noch in Arbeit ist:
 ```
 Header:
-  * Status: 200 OK
-
+  - Status: 200 OK
 Body:
 {
   "status": "PROCESSING"
@@ -166,12 +104,12 @@ Bitte in 20s (Empfehlung) erneut abfragen.
 **(b)** Response für den Fall, dass der Europace-Report erstellt wurde:
 ```
 Header:
-  * Status: 303 SEE OTHER
-  * Location: https://{path-to-file}
+  - Status: 303 SEE OTHER
+  - Location: https://{path-to-file}
 ```
 Die Header-Variable `Location` zeigt auf die Reportdaten.
 
-### 3. Report abholen
+#### 3. Report abholen
 
 Dieser Schritt ist für alle Europace-Reports gleich.
 
@@ -184,17 +122,17 @@ https://greta-462912489437-eu-central-1.s3.amazonaws.com/prod/{reporttyp}/{repor
 
 Request:
 ```
-GET https://greta-462912489437-eu-central-1.s3.amazonaws.com/prod/{reporttyp}/{report-processing-id}/Ep2_Reports_....zip?X-Amz-Security-Token=...&X-Amz-Signature=...
+curl --location --request GET 'https://greta-462912489437-eu-central-1.s3.amazonaws.com/prod/{reporttyp}/{report-processing-id}/Ep2_Reports_....zip?X-Amz-Security-Token=...&X-Amz-Signature=...
 ```
 
 Response:
 ```
 Header:
-  * Status: 200 OK
-
+  - Status: 200 OK
 Body:
 <File>
 ```
+Den Dateityp von <file> kann den Europace-Reports entnommen werden.
 
 ## Nutzungsbedingungen
 Die APIs werden unter folgenden [Nutzungsbedingungen](https://docs.api.europace.de/nutzungsbedingungen/) zur Verfügung gestellt.

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,11 @@
+<html>
+<head>
+  <meta charset="utf-8"> <!-- Important: rapi-doc uses utf8 charecters -->
+  <script type="module" src="https://unpkg.com/rapidoc/dist/rapidoc-min.js"></script>
+</head>
+<body>
+  <rapi-doc 
+    spec-url="https://report.api.europace.de/documentation" 
+  > </rapi-doc>
+</body> 
+</html>


### PR DESCRIPTION
- Dokumentation etwas angepasst um die Struktur klarer zu machen (dabei habe ich mich an der Unterlagen-API Doku orientiert)
- GitHub Page als vollwertige API Dokumentation
